### PR TITLE
json_response has no label key when no label provided

### DIFF
--- a/blockchain/wallet.py
+++ b/blockchain/wallet.py
@@ -153,7 +153,7 @@ class Wallet:
         self.parse_error(json_response)
         return Address(0,
                         json_response['address'],
-                        json_response['label'],
+                        json_response.get('label', None),
                         0)
                         
     def archive_address(self, address):


### PR DESCRIPTION
This fixes KeyError when no label is provided during call.