### PR TITLE
enable testnet5 support

### DIFF
--- a/blockchain/util.py
+++ b/blockchain/util.py
@@ -17,7 +17,8 @@ else:
     from urllib import urlencode
 
 
-def call_api(resource, data=None, base_url=BASE_URL):
+def call_api(resource, data=None, base_url=None):
+    base_url = BASE_URL if base_url is None else base_url
     try:
         payload = None if data is None else urlencode(data)
         if py_version >= 3 and payload is not None:


### PR DESCRIPTION
By reading BASE_URL at function call time instead of function definition time users of the SDK can change the client to testnet5 by setting blockchain.util.BASE_URL. (Similar to how timeout can be set to a custom value)