### PR TITLE
Added fields for addr_tag and addr_tag_link to the Output object

### DIFF
--- a/blockchain/blockexplorer.py
+++ b/blockchain/blockexplorer.py
@@ -354,6 +354,14 @@ class Output:
         self.tx_index = o['tx_index']
         self.script = o['script']
         self.spent = o['spent']
+        self.addr_tag_link = None
+        self.addr_tag = None
+
+        if 'addr_tag_link' in o:
+            self.addr_tag_link = o['addr_tag_link']
+           
+        if 'addr_tag' in o:
+            self.addr_tag = o['addr_tag']
 
 
 class Transaction:


### PR DESCRIPTION
Just wanted to add the fields for addr_tag and addr_tag_link for Output objects so that I can pull the same information available from the web :)

eg. [https://blockchain.info/address/1Ez69SnzzmePmZX3WpEzMKTrcBF2gpNQ55?format=json](https://blockchain.info/address/1Ez69SnzzmePmZX3WpEzMKTrcBF2gpNQ55?format=json)
Contains:
`
"out": [
{
"addr_tag_link": "http://blog.cryptocrumb.com/2014/06/us-marshals-bitcoin-auction-not-clean.html",
"addr_tag": "US Marshal Auction coins",
`

Which previously you couldn't get from the API, this is now available in the same place as the JSON in the fields in the Output object as `self.addr_tag_link` and `self.addr_tag`. Both default to None if they are not present.

Cheers!
Andrew