### PR TITLE
Handle to error of API values with comma

### DIFF
--- a/blockchain/exchangerates.py
+++ b/blockchain/exchangerates.py
@@ -40,7 +40,7 @@ def to_btc(ccy, value, api_code=None):
     res = 'tobtc?currency={0}&value={1}'.format(ccy, value)
     if api_code is not None:
         res += '&api_code=' + api_code
-    return float(util.call_api(res))
+    return float(util.call_api(res).replace(',',''))
 
 
 def to_fiat(ccy, value, api_code=None):
@@ -48,14 +48,14 @@ def to_fiat(ccy, value, api_code=None):
 
     :param str ccy: currency code
     :param float value: BTC value to convert
-    :param str api_code: Blockchain.info API code
+    :param str api_code: Blockchain.info API codeigger
     :return: the value in fiat currency
     """
 
     res = 'frombtc?currency={0}&value={1}'.format(ccy, value*100000000)
     if api_code is not None:
         res += '&api_code=' + api_code
-    return float(util.call_api(res))
+    return float(util.call_api(res).replace(',',''))
 
 
 class Currency:

--- a/blockchain/util.py
+++ b/blockchain/util.py
@@ -32,7 +32,8 @@ def call_api(resource, data=None, base_url=None):
 
 def handle_response(response):
     # urllib returns different types in Python 2 and 3 (str vs bytes)
+    # the replace function extract the comma in float values bigger than 999
     if isinstance(response, str):
-        return response
+        return response.replace(',','')
     else:
-        return response.decode('utf-8')
+        return response.decode('utf-8').replace(',','')

--- a/blockchain/util.py
+++ b/blockchain/util.py
@@ -34,6 +34,6 @@ def handle_response(response):
     # urllib returns different types in Python 2 and 3 (str vs bytes)
     # the replace function extract the comma in float values bigger than 999
     if isinstance(response, str):
-        return response.replace(',','')
+        return response
     else:
-        return response.decode('utf-8').replace(',','')
+        return response.decode('utf-8')


### PR DESCRIPTION
I just added a simple solution to avoid errors in functions to_btc and to_fiat when values returned are bigger than 999.