### PR TITLE
`blockexplorer.get_multi_address(...)` requests failing fix 

### DIFF
--- a/blockchain/blockexplorer.py
+++ b/blockchain/blockexplorer.py
@@ -300,9 +300,6 @@ class SimpleAddress:
         if hasattr(a,'change_index') and hasattr(a,'account_index'):
             self.change_index = a['change_index']
             self.account_index = a['account_index']
-        else:
-            self.change_index = 'unknown'
-            self.account_index = 'unknown'
 
 
 class MultiAddress:

--- a/blockchain/blockexplorer.py
+++ b/blockchain/blockexplorer.py
@@ -297,8 +297,12 @@ class SimpleAddress:
         self.total_received = a['total_received']
         self.total_sent = a['total_sent']
         self.final_balance = a['final_balance']
-        self.change_index = a['change_index']
-        self.account_index = a['account_index']
+        if hasattr(a,'change_index') and hasattr(a,'account_index'):
+            self.change_index = a['change_index']
+            self.account_index = a['account_index']
+        else:
+            self.change_index = 'unknown'
+            self.account_index = 'unknown'
 
 
 class MultiAddress:


### PR DESCRIPTION
Requests for the multi-address API are failing due to missing fields (at least for the free API calls). The missing fields are `account_index` and `change_index`.